### PR TITLE
fix: update total_games method to count @games instead of @matches

### DIFF
--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -67,7 +67,7 @@ class StatTracker
   end 
  
   def total_games
-    @matches.count
+    @games.count
   end
 
   def home_wins


### PR DESCRIPTION
This pull request includes a small change to the `lib/stat_tracker.rb` file. The change updates the `total_games` method to use the `@games` instance variable instead of `@matches` for counting the total number of games. 

* [`lib/stat_tracker.rb`](diffhunk://#diff-45d7cced37120747def456e491f15129003f88faffbac670200e8011635d3f1fL70-R70): Modified the `total_games` method to use `@games.count` instead of `@matches.count`.