### PR TITLE
Game team integration

### DIFF
--- a/lib/game.rb
+++ b/lib/game.rb
@@ -62,10 +62,10 @@ class Game
     return nil if !all_teams || all_teams.length == 0
 
     @game_stats[:away][:team] = all_teams.find do |team|
-      team[:team_id].to_i == @game_stats[:away][:team_id]
+      team.team_id.to_i == @game_stats[:away][:team_id]
     end
     @game_stats[:home][:team] = all_teams.find do |team|
-      team[:team_id].to_i == @game_stats[:home][:team_id]
+      team.team_id.to_i == @game_stats[:home][:team_id]
     end
   end
 

--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -1,8 +1,3 @@
-require 'csv'
-require 'pry'
-require './lib/game'
-require './lib/team'
-
 class StatTracker
   attr_reader :games, :teams, :game_teams, :matches, :clubs
 

--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -1,6 +1,7 @@
 require 'csv'
 require 'pry'
 require './lib/game'
+require './lib/team'
 
 class StatTracker
   attr_reader :games, :teams, :game_teams, :matches, :clubs
@@ -9,8 +10,13 @@ class StatTracker
     @games = []
     @teams = []
     @game_teams = []
-    @matches = []
-    @clubs = []
+
+    @matches = []     #Array of actual game objects
+    @clubs = []       #Array of actual team objects
+
+    #Create games and teams, and make appropriate connections / associations
+    # create_all_games()
+    # create_all_teams()
   end
 
   def self.from_csv(locations)
@@ -28,6 +34,10 @@ class StatTracker
       # binding.pry
       stat_tracker.game_teams << row
     end
+
+    #Now that we have raw data, create games and teams, and make appropriate connections / associations
+    stat_tracker.create_all_games()
+    stat_tracker.create_all_teams()
 
     stat_tracker
   end
@@ -152,7 +162,7 @@ class StatTracker
 
   def create_all_teams
     @teams.each do |team|
-      @clubs << Team.new(team[:team_id], team[:teamName])
+      @clubs << Team.new(team)
     end
   end
 

--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -36,8 +36,10 @@ class StatTracker
     end
 
     #Now that we have raw data, create games and teams, and make appropriate connections / associations
+    #NOTE: what immediately follows is the most 'expensive' part of all methods / classes
     stat_tracker.create_all_games()
     stat_tracker.create_all_teams()
+    stat_tracker.associate_games_and_teams()
 
     stat_tracker
   end
@@ -282,5 +284,16 @@ class StatTracker
     games_by_season
   end
 
+  def associate_games_and_teams()
+    #First, associate teams to each game:
+    @matches.each do |game|
+      game.associate_teams_with_game(@clubs)
+    end
+
+    #Now, build array of games each team has played in:
+    @clubs.each do |team|
+      team.associate_games_with_team(@matches)
+    end
+  end
 
 end

--- a/lib/team.rb
+++ b/lib/team.rb
@@ -1,14 +1,17 @@
 class Team
-  attr_reader :team_id, :team_name
+  attr_reader :team_id, :team_name, :games_played
 
   def initialize(team_data)
-    @team_id = team_data[:team_id]
+    @team_id = team_data[:team_id].to_i
     @team_name = team_data[:teamname]
 
     @games_played = []      #Array of all games (objects) this team has played in (home and away)
   end
 
   def associate_games_with_team(all_games)
+
+    # binding.pry
+
     @games_played = all_games.find_all do |game|
       game.game_stats[:home][:team_id] == @team_id || game.game_stats[:away][:team_id] == @team_id
     end

--- a/lib/team.rb
+++ b/lib/team.rb
@@ -4,6 +4,23 @@ class Team
   def initialize(team_data)
     @team_id = team_data[:team_id]
     @team_name = team_data[:teamname]
+
+    @games_played = []      #Array of all games (objects) this team has played in (home and away)
   end
+
+  def associate_games_with_team(all_games)
+    @games_played = all_games.find_all do |game|
+      game.game_stats[:home][:team_id] == @team_id || game.game_stats[:away][:team_id] == @team_id
+    end
+
+    #Optional implementation: separate into two instance vars, @home_games_played and @away_games_played:
+    # all_games.each do |game|
+    #   if game.game_stats[:home][:team_id] == @team_id
+    #     @home_games_played << game
+    #   elsif game.game_stats[:away][:team_id] == @team_id
+    #     @away_games_played << game
+    #   end
+  end
+
 end
    

--- a/lib/team.rb
+++ b/lib/team.rb
@@ -3,7 +3,7 @@ class Team
 
   def initialize(team_data)
     @team_id = team_data[:team_id]
-    @team_name = team_data[:teamName]
+    @team_name = team_data[:teamname]
   end
 end
    

--- a/runner.rb
+++ b/runner.rb
@@ -11,6 +11,7 @@ locations = {
 }
 
 stat_tracker = StatTracker.from_csv(locations)
-stat_tracker.create_all_games
+# stat_tracker.create_all_games
+# stat_tracker.create_all_teams
 
 binding.pry

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,8 @@ end
 
 require 'rspec'
 require './lib/stat_tracker'
+require './lib/game'
+require './lib/team'
 require 'pry'
 require 'csv'
 

--- a/spec/stattracker_spec.rb
+++ b/spec/stattracker_spec.rb
@@ -2,16 +2,26 @@ require 'spec_helper'
 require 'csv' 
 
 RSpec.describe StatTracker do
-  let(:locations) do
-    {
+  # let(:locations) do
+  #   {
+  #     games: './data/games.csv',        
+  #     teams: './data/teams.csv',        
+  #     game_teams: './data/game_teams.csv' 
+  #   }
+  # end
+
+  before(:all) do
+    locations = {
       games: './data/games.csv',        
       teams: './data/teams.csv',        
       game_teams: './data/game_teams.csv' 
     }
-  end
 
+    @stat_tracker = StatTracker.from_csv(locations)   #This now also builds the game objects (@matches) and team objects (@clubs)
+  end
+  
   before(:each) do
-    @stat_tracker = StatTracker.from_csv(locations)
+    # @stat_tracker = StatTracker.from_csv(locations)
     # @stat_tracker.create_all_games
 
     #Here's another instance with shorter datasets loaded for simpler testing:
@@ -21,7 +31,10 @@ RSpec.describe StatTracker do
       game_teams: './data/short_test_game_teams.csv',
     }
     @stat_tracker_short = StatTracker.from_csv(shorter_data_locations)
-    @stat_tracker_short.create_all_games
+    # @stat_tracker_short.create_all_games
+
+    # binding.pry
+
   end
 
   

--- a/spec/stattracker_spec.rb
+++ b/spec/stattracker_spec.rb
@@ -96,16 +96,18 @@ RSpec.describe StatTracker do
     end
   end
 
-   describe "creates all games in a dataset" do
+  describe "creates all games in a dataset" do
     it "returns all games in a smaller dataset" do
       expect(@stat_tracker_short.matches.length).to eq(20)
     end
-   end
+  end
 
 
-   describe '#highest_scoring_visitor' do
+  describe '#highest_scoring_visitor' do
     it 'returns the team with the highest average score when visitor from short_games.csv' do
-    expect(@stat_tracker_short.highest_scoring_visitor).to eq("Orlando City SC")
+      expect(@stat_tracker_short.highest_scoring_visitor).to eq("Orlando City SC")
+    end
+  end
 
   describe '#count_of_games_by_season' do
     it 'returns a hash with season names as keys and counts of games as values' do


### PR DESCRIPTION
This branch makes the Game objects and Team objects fully functional, properly connected, and properly initialized.  Here are the main issues of note:
-Team objects stored in @clubs have an ID that is now an integer for easier searching / matching
-StatTracker#from_csv method now fully builds all Game and Team objects automatically.  Once it returns a StatTracker object (like @stat_tracker in the RSpec file), there is no need to run things like stat_tracker.create_all_objects anymore.
-All Game objects now have Team objects associated with them.  For example, to get the actual Team object (and therefore access things like the team name), you can just access @matches[index].game_stats[:home or :away][:team].
-All Team objects now have an array called @games_played.  For example, to access a specific game a team played, it might be something like @clubs[index].games_played[another index].  I'm not sure if this will be helpful in our methods, but I added it in case it is, since it provides a different way of organizing the information.
-The stattracker_spec.rb file now only creates the StatTracker object once, so that it doesn't load the data for every single test.  I had to create a before(:all) to accomplish this, and had to move locations within it, since RSpec didn't like it otherwise (gave curious errors).
-Simplified the 'require' statements, so they should all be centralized in spec_helper.rb and connect / work correctly.

Moving forward, we can fully use @matches for accessing game information, and @clubs for accessing team information, since those are the actual objects from the Game and Team classes.  The @games, @teams, and @game_teams variables still exist so that old methods don't break (before refactoring).

I will work on trying to make object loading and creation faster next (Saturday).