### PR TITLE
Most n least tackles

### DIFF
--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -385,5 +385,47 @@ class StatTracker
 
     @teams.find { |team| team[:team_id] == worst_team_id }[:teamname]
   end
+
+  def most_tackles(season)
+    team_tackles = {}
+
+    # Iterate through each game team to calculate tackles for each team in the given season
+    @game_teams.each do |game_team|
+      matching_game = @games.find { |g| g[:game_id] == game_team[:game_id] }
+      next unless matching_game && matching_game[:season] == season
+
+      team_id = game_team[:team_id]
+      team_tackles[team_id] ||= 0
+      team_tackles[team_id] += game_team[:tackles].to_i
+    end
+
+    return nil if team_tackles.empty?
+
+    # Find the team with the most tackles
+    most_tackles_team_id = team_tackles.max_by { |team_id, tackles| tackles }&.first
+
+    @teams.find { |team| team[:team_id] == most_tackles_team_id }[:teamname]
+  end
+
+  def fewest_tackles(season)
+    team_tackles = {}
+
+    # Iterate through each game team to calculate tackles for each team in the given season
+    @game_teams.each do |game_team|
+      matching_game = @games.find { |g| g[:game_id] == game_team[:game_id] }
+      next unless matching_game && matching_game[:season] == season
+
+      team_id = game_team[:team_id]
+      team_tackles[team_id] ||= 0
+      team_tackles[team_id] += game_team[:tackles].to_i
+    end
+
+    return nil if team_tackles.empty?
+
+    # Find the team with the fewest tackles
+    fewest_tackles_team_id = team_tackles.min_by { |team_id, tackles| tackles }&.first
+
+    @teams.find { |team| team[:team_id] == fewest_tackles_team_id }[:teamname]
+  end
 end
 

--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -341,4 +341,45 @@ class StatTracker
   def count_of_teams
     @teams.count
   end
+
+  def most_accurate_team(season)
+    team_accuracy = {}
+
+    @game_teams.each do |game_team|
+      matching_game = @games.find { |g| g[:game_id] == game_team[:game_id] }
+      next unless matching_game && matching_game[:season] == season
+
+      team_id = game_team[:team_id]
+      team_accuracy[team_id] ||= { goals: 0, shots: 0 }
+      team_accuracy[team_id][:goals] += game_team[:goals].to_i
+      team_accuracy[team_id][:shots] += game_team[:shots].to_i
+    end
+
+    return nil if team_accuracy.empty?
+
+    best_team_id = team_accuracy.max_by { |team_id, stats| stats[:goals].to_f / stats[:shots] }&.first
+
+    @teams.find { |team| team[:team_id] == best_team_id }[:teamname]
+  end
+
+  def least_accurate_team(season)
+    team_accuracy = {}
+
+    @game_teams.each do |game_team|
+      matching_game = @games.find { |g| g[:game_id] == game_team[:game_id] }
+      next unless matching_game && matching_game[:season] == season
+
+      team_id = game_team[:team_id]
+      team_accuracy[team_id] ||= { goals: 0, shots: 0 }
+      team_accuracy[team_id][:goals] += game_team[:goals].to_i
+      team_accuracy[team_id][:shots] += game_team[:shots].to_i
+    end
+
+    return nil if team_accuracy.empty?
+
+    worst_team_id = team_accuracy.min_by { |team_id, stats| stats[:goals].to_f / stats[:shots] }&.first
+
+    @teams.find { |team| team[:team_id] == worst_team_id }[:teamname]
+  end
 end
+

--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -345,6 +345,7 @@ class StatTracker
   def most_accurate_team(season)
     team_accuracy = {}
 
+    # Iterate through each game team to calculate goals and shots for each team in the given season
     @game_teams.each do |game_team|
       matching_game = @games.find { |g| g[:game_id] == game_team[:game_id] }
       next unless matching_game && matching_game[:season] == season
@@ -357,6 +358,7 @@ class StatTracker
 
     return nil if team_accuracy.empty?
 
+    # Find the team with the highest goals-to-shots ratio
     best_team_id = team_accuracy.max_by { |team_id, stats| stats[:goals].to_f / stats[:shots] }&.first
 
     @teams.find { |team| team[:team_id] == best_team_id }[:teamname]
@@ -365,6 +367,7 @@ class StatTracker
   def least_accurate_team(season)
     team_accuracy = {}
 
+    # Iterate through each game team to calculate goals and shots for each team in the given season
     @game_teams.each do |game_team|
       matching_game = @games.find { |g| g[:game_id] == game_team[:game_id] }
       next unless matching_game && matching_game[:season] == season
@@ -377,6 +380,7 @@ class StatTracker
 
     return nil if team_accuracy.empty?
 
+    # Find the team with the lowest goals-to-shots ratio
     worst_team_id = team_accuracy.min_by { |team_id, stats| stats[:goals].to_f / stats[:shots] }&.first
 
     @teams.find { |team| team[:team_id] == worst_team_id }[:teamname]

--- a/spec/stattracker_spec.rb
+++ b/spec/stattracker_spec.rb
@@ -173,16 +173,34 @@ RSpec.describe StatTracker do
   end
 
   describe '#most_accurate_team' do
-    it 'returns the team with the highest shots-to-goals ratio for the season' do
+    xit 'returns the team with the highest shots-to-goals ratio for the season' do
       expect(@stat_tracker.most_accurate_team("20132014")).to eq "Real Salt Lake"
       expect(@stat_tracker.most_accurate_team("20142015")).to eq "Toronto FC"
+    end
+
+    xit 'returns nil for all seasons in short_test_games.csv' do
+      expect(@stat_tracker_short.most_accurate_team("20122013")).to be_nil
+      expect(@stat_tracker_short.most_accurate_team("20132014")).to be_nil
+      expect(@stat_tracker_short.most_accurate_team("20142015")).to be_nil
+      expect(@stat_tracker_short.most_accurate_team("20152016")).to be_nil
+      expect(@stat_tracker_short.most_accurate_team("20162017")).to be_nil
+      expect(@stat_tracker_short.most_accurate_team("20172018")).to be_nil
     end
   end
 
   describe '#least_accurate_team' do
-    it 'returns the team with the lowest shots-to-goals ratio for the season' do
+    xit 'returns the team with the lowest shots-to-goals ratio for the season' do
       expect(@stat_tracker.least_accurate_team("20132014")).to eq "New York City FC"
       expect(@stat_tracker.least_accurate_team("20142015")). to eq "Columbus Crew SC"
+    end
+
+    xit 'returns nil for all seasons in short_test_games.csv' do
+      expect(@stat_tracker_short.least_accurate_team("20122013")).to be_nil
+      expect(@stat_tracker_short.least_accurate_team("20132014")).to be_nil
+      expect(@stat_tracker_short.least_accurate_team("20142015")).to be_nil
+      expect(@stat_tracker_short.least_accurate_team("20152016")).to be_nil
+      expect(@stat_tracker_short.least_accurate_team("20162017")).to be_nil
+      expect(@stat_tracker_short.least_accurate_team("20172018")).to be_nil
     end
   end
 end

--- a/spec/stattracker_spec.rb
+++ b/spec/stattracker_spec.rb
@@ -172,35 +172,17 @@ RSpec.describe StatTracker do
     end
   end
 
-  describe '#most_accurate_team' do
+  describe '#most_accurate_team' do #placeholder
     xit 'returns the team with the highest shots-to-goals ratio for the season' do
       expect(@stat_tracker.most_accurate_team("20132014")).to eq "Real Salt Lake"
-      expect(@stat_tracker.most_accurate_team("20142015")).to eq "Toronto FC"
-    end
-
-    xit 'returns nil for all seasons in short_test_games.csv' do
-      expect(@stat_tracker_short.most_accurate_team("20122013")).to be_nil
-      expect(@stat_tracker_short.most_accurate_team("20132014")).to be_nil
-      expect(@stat_tracker_short.most_accurate_team("20142015")).to be_nil
-      expect(@stat_tracker_short.most_accurate_team("20152016")).to be_nil
-      expect(@stat_tracker_short.most_accurate_team("20162017")).to be_nil
-      expect(@stat_tracker_short.most_accurate_team("20172018")).to be_nil
+      expect(@stat_tracker.most_accurate_team("20142015")). to eq "Toronto FC"
     end
   end
 
-  describe '#least_accurate_team' do
+  describe '#least_accurate_team' do #placeholder
     xit 'returns the team with the lowest shots-to-goals ratio for the season' do
       expect(@stat_tracker.least_accurate_team("20132014")).to eq "New York City FC"
       expect(@stat_tracker.least_accurate_team("20142015")). to eq "Columbus Crew SC"
-    end
-
-    xit 'returns nil for all seasons in short_test_games.csv' do
-      expect(@stat_tracker_short.least_accurate_team("20122013")).to be_nil
-      expect(@stat_tracker_short.least_accurate_team("20132014")).to be_nil
-      expect(@stat_tracker_short.least_accurate_team("20142015")).to be_nil
-      expect(@stat_tracker_short.least_accurate_team("20152016")).to be_nil
-      expect(@stat_tracker_short.least_accurate_team("20162017")).to be_nil
-      expect(@stat_tracker_short.least_accurate_team("20172018")).to be_nil
     end
   end
 end

--- a/spec/stattracker_spec.rb
+++ b/spec/stattracker_spec.rb
@@ -185,5 +185,19 @@ RSpec.describe StatTracker do
       expect(@stat_tracker.least_accurate_team("20142015")). to eq "Columbus Crew SC"
     end
   end
+
+  describe '#most_tackles' do #placeholder
+    xit 'returns the team with the most tackles for the season' do
+      expect(@stat_tracker.most_tackles("20132014")).to eq "FC Cincinnati"
+      expect(@stat_tracker.most_tackles("20142015")).to eq "Seattle Sounders FC"
+    end
+  end
+
+  describe '#fewest_tackles' do #placeholder
+    xit 'returns the team with the fewest tackles for the season' do
+      expect(@stat_tracker.fewest_tackles("20132014")).to eq "Atlanta United"
+      expect(@stat_tracker.fewest_tackles("20142015")).to eq "Orlando City SC"
+    end
+  end
 end
 

--- a/spec/stattracker_spec.rb
+++ b/spec/stattracker_spec.rb
@@ -171,5 +171,19 @@ RSpec.describe StatTracker do
       expect(@stat_tracker_short.worst_offense).to eq("Chicago Red Stars")
     end
   end
+
+  describe '#most_accurate_team' do
+    it 'returns the team with the highest shots-to-goals ratio for the season' do
+      expect(@stat_tracker.most_accurate_team("20132014")).to eq "Real Salt Lake"
+      expect(@stat_tracker.most_accurate_team("20142015")).to eq "Toronto FC"
+    end
+  end
+
+  describe '#least_accurate_team' do
+    it 'returns the team with the lowest shots-to-goals ratio for the season' do
+      expect(@stat_tracker.least_accurate_team("20132014")).to eq "New York City FC"
+      expect(@stat_tracker.least_accurate_team("20142015")). to eq "Columbus Crew SC"
+    end
+  end
 end
 


### PR DESCRIPTION
This pull request introduces several new methods to the `StatTracker` class to compute various team statistics for a given season. Additionally, placeholder tests for these methods have been added to the `stattracker_spec.rb` file.

New methods in `StatTracker`:

* [`most_accurate_team(season)`](diffhunk://#diff-45d7cced37120747def456e491f15129003f88faffbac670200e8011635d3f1fR344-R431): Calculates and returns the team with the highest goals-to-shots ratio for the specified season.
* [`least_accurate_team(season)`](diffhunk://#diff-45d7cced37120747def456e491f15129003f88faffbac670200e8011635d3f1fR344-R431): Calculates and returns the team with the lowest goals-to-shots ratio for the specified season.
* [`most_tackles(season)`](diffhunk://#diff-45d7cced37120747def456e491f15129003f88faffbac670200e8011635d3f1fR344-R431): Calculates and returns the team with the most tackles for the specified season.
* [`fewest_tackles(season)`](diffhunk://#diff-45d7cced37120747def456e491f15129003f88faffbac670200e8011635d3f1fR344-R431): Calculates and returns the team with the fewest tackles for the specified season.

Placeholder tests in `stattracker_spec.rb`:

* Added placeholder tests for `most_accurate_team`, `least_accurate_team`, `most_tackles`, and `fewest_tackles` methods. These tests are currently marked as pending with `xit`.